### PR TITLE
[AutoBalancer/AutoBalancer.cpp, AutoBalancer/GaitGenerator.*] update …

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -891,7 +891,7 @@ namespace rats
                                     const std::vector<step_node>& initial_support_leg_steps,
                                     const std::vector<step_node>& initial_swing_leg_dst_steps,
                                     const double delay = 1.6);
-    bool proc_one_tick ();
+    bool proc_one_tick (const int kuroiwa_flag = 0);
     void append_footstep_nodes (const std::vector<std::string>& _legs, const std::vector<coordinates>& _fss)
     {
         std::vector<step_node> tmp_sns;


### PR DESCRIPTION
…emergencyStop in order to stop in one step and enable an emergencyStop trigger from Stabilizer

capture pointベースでgo-pos中に転けそうになったら歩くのをやめる機能が欲しくて，

- go-pos中に歩行を止める機能を，1歩で止まるようにテンポラリの変更
- STでCapturePointがずれたら上記の歩行を止める機能を呼ぶように変更

を加えました．

前者は他の機能（フットステップを上書きする機能）を動かなくしていて，
後者は実機で未確認なので危ない，という問題があるので，
それの対策として，
通常の状態は今回のdiffは何もしないで，

```bash
rtconf localhost:2809/abc.rtc set debugLevel 3
```

とすると，今回のdiffが効いてくるようにしました．

直前にdiffを入れるのは良くないと思うのですが，ナロースペースを制限時間内でクリアするには欲しい機能ですのでマージしていただければ幸いです．

ナロースペースの作戦として

1. go-pos決め打ち動作を送っていけるところまで行く
   - 足の滑りに再現性がなく，クリアするときもあれば途中で壁にぶつかって転倒する場合もある
1. 転けそうになったら今回のdiffで止まってくれる
1. そのあとはrvizで微修正して決め打ちgo-posをまた送る

を考えています．
