### PR TITLE
fix bug on fullbody ik while start/stopAutobalancer

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -735,6 +735,7 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
         rel_ref_zmp = input_zmp;
         fik->d_root_height = 0.0;
       }
+      fik->storeCurrentParameters();
       // Transition
       if (!is_transition_interpolator_empty) {
         // transition_interpolator_ratio 0=>1 : IDLE => ABC
@@ -768,7 +769,6 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
                   << "] Finished cleanup" << std::endl;
         control_mode = MODE_IDLE;
       }
-      fik->storeCurrentParameters();
       m_robot->calcForwardKinematics();
       hrp::Vector3 tmp_ref_cog(m_robot->calcCM());
       ref_cog(2) = tmp_ref_cog(2);


### PR DESCRIPTION
（他の人のブランチでも影響ありそうなバグフィックスはメモとして自分のブランチにPRするようにしました．）

前回のIKの結果をstoreするべきで，
https://github.com/ishiguroJSK/hrpsys-base/blob/fullbody-ik-master/rtc/AutoBalancer/AutoBalancer.cpp#L543-L562
のあとにstoreすると，start/stopAutobalaner中に関節角が振動する．
実機でプロットして治ることを確認した．

FYI： @Kindsenior @ishiguroJSK