### PR TITLE
add libproj-dev to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <build_depend>openhrp3</build_depend>
   <build_depend>python-tk</build_depend>
   <build_depend>sdl</build_depend>
+  <build_depend>proj</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>glut</run_depend>


### PR DESCRIPTION
ubuntu16で次のようなエラーがでました

make[2]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/libproj.so', needed by 'lib/ApproximateVoxelGridFilter.so'.  Stop.

libprij-devをインストールすると解決したので、package.xml追加し、rosdep installで自動的に入るようにしました