### PR TITLE
fix contactstates

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1134,7 +1134,7 @@ void AutoBalancer::setABCData2ST()
     st->qRef[i] =  m_robot->joint(i)->q;
     st->qRefSeq[i] =  m_qRefSeq.data[i];
   }
-  for (size_t i; i < m_contactStates.data.length(); i++) {
+  for (size_t i = 0; i < m_contactStates.data.length(); i++) {
     st->ref_contact_states[i] = m_contactStates.data[i];
     st->toeheel_ratio[i] = m_toeheelRatio.data[i];
     st->controlSwingSupportTime[i] = m_controlSwingSupportTime.data[i];


### PR DESCRIPTION
is_ik_enableやis_feedback_enableがfalseになっていると、https://github.com/YutaKojio/hrpsys-base/blob/6b442cfe1e80f355d5ec8cea16443ac5fa269d99/rtc/AutoBalancer/Stabilizer.cpp#L606 のee_posやee_rotのサイズがcontactstateのサイズと異なるので、あぶないかもしれません。