### PR TITLE
[python/hrpsys_config.py] switch rfu and es, and correct force flow

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -465,10 +465,10 @@ class HrpsysConfigurator(object):
                              self.st.port(sen + "Ref"))
                 connectPorts(self.abc.port("limbCOPOffset_"+sen),
                              self.st.port("limbCOPOffset_"+sen))
-            if self.rfu:
-                ref_force_port_from = self.rfu.port("ref_"+sen+"Out")
-            elif self.es:
+            if self.es:
                 ref_force_port_from = self.es.port(sen+"Out")
+            elif self.rfu:
+                ref_force_port_from = self.rfu.port("ref_"+sen+"Out")
             else:
                 ref_force_port_from = self.sh.port(sen+"Out")
             if self.ic:
@@ -477,16 +477,16 @@ class HrpsysConfigurator(object):
             if self.abc:
                 connectPorts(ref_force_port_from,
                              self.abc.port("ref_" + sen))
-            if self.es:
+                if self.rfu:
                 connectPorts(self.sh.port(sen+"Out"),
-                             self.es.port(sen+"In"))
-                if self.rfu:
-                    connectPorts(self.es.port(sen+"Out"),
                                  self.rfu.port("ref_" + sen+"In"))
+                if self.es:
+                    connectPorts(self.rfu.port("ref_" + sen+"Out"),
+                                 self.es.port(sen+"In"))
             else:
-                if self.rfu:
+                if self.es:
                     connectPorts(self.sh.port(sen+"Out"),
-                                 self.rfu.port("ref_" + sen+"In"))
+                                 self.es.port(sen+"In"))
 
         #  actual force sensors
         if self.rmfo:
@@ -521,8 +521,7 @@ class HrpsysConfigurator(object):
                 connectPorts(self.sh.port("baseRpyOut"), self.ic.port("baseRpyIn"))
         # connection for rfu
         if self.rfu:
-            if self.es:
-                connectPorts(self.es.port("q"), self.rfu.port("qRef"))
+            connectPorts(self.sh.port("qOut"), self.rfu.port("qRef"))
             if StrictVersion(self.seq_version) >= StrictVersion('315.3.0'):
                 connectPorts(self.sh.port("basePosOut"), self.rfu.port("basePosIn"))
                 connectPorts(self.sh.port("baseRpyOut"), self.rfu.port("baseRpyIn"))


### PR DESCRIPTION
rfuがesの後にあったので，esが入ってref-forceの更新を止めるはずが，rfuによって更新されるという現象が起きていました．
rfuとesの順番を変更して，ポートのつなぎ方を変更しました．

順番を変更しているのは，Choreonoid上では[この変更](https://github.com/YutaKojio/rtmros_choreonoid/pull/3/commits/127337e6d961abf2e44dde2e818fd827de460724), 実機では[この変更](https://github.com/YutaKojio/trans_system/pull/1/commits/6ec17cf99d1b0e00de3cd2cd2ebb54f47e4dabfa)に相当します．
また，rosのtopicとして `ref_**sensor` という名前でpublishされている値を，esの後の値，つまりはesによって更新が止められたものにするためには，[この変更](https://github.com/YutaKojio/rtmros_common/pull/2/commits/e23632a4e71695631c7fe6f5ae125b7501ceccfe)を取り入れる必要があります．