### PR TITLE
remove Stabilizer diff

### DIFF
--- a/rtc/Stabilizer/CMakeLists.txt
+++ b/rtc/Stabilizer/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(BUILD_STABILIZER "Build Stabilizer RTC" OFF)
+option(BUILD_STABILIZER "Build Stabilizer RTC" ON)
 
 if(NOT BUILD_STABILIZER)
   return()
@@ -11,7 +11,7 @@ if(USE_QPOASES)
   add_definitions(-DUSE_QPOASES)
 endif()
 
-set(comp_sources Integrator.cpp TwoDofController.cpp Stabilizer.cpp StabilizerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp ../TorqueFilter/IIRFilter.cpp)
+set(comp_sources Integrator.cpp TwoDofController.cpp Stabilizer.cpp StabilizerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp ../TorqueFilter/IIRFilter.h)
 if(USE_QPOASES)
   set(libs hrpModel-3.1 hrpUtil-3.1 hrpsysBaseStub qpOASES)
 else()

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -334,8 +334,6 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
       }
   }
 
-  // Generate FIK
-  fik = fikPtr(new FullbodyInverseKinematicsSolver(m_robot, std::string(m_profile.instance_name), dt));
 
   // parameters for TPCC
   act_zmp = hrp::Vector3::Zero();
@@ -1203,7 +1201,7 @@ void Stabilizer::getTargetParameters ()
     prev_ref_zmp = ref_zmp;
     ref_zmp = tmp_ref_zmp;
   }
-  ref_cog_wld = ref_cog = m_robot->calcCM();
+  ref_cog = m_robot->calcCM();
   ref_total_force = hrp::Vector3::Zero();
   ref_total_moment = hrp::Vector3::Zero(); // Total moment around reference ZMP tmp
   ref_total_foot_origin_moment = hrp::Vector3::Zero();
@@ -1515,12 +1513,12 @@ void Stabilizer::calcTPCC() {
                                   + k_tpcc_x[i] * transition_smooth_gain * dcog(i);
         newcog(i) = uu * dt + cog(i);
       }
+
       moveBasePosRotForBodyRPYControl ();
 
       // target at ee => target at link-origin
       hrp::Vector3 target_link_p[stikp.size()];
       hrp::Matrix33 target_link_R[stikp.size()];
-        
       for (size_t i = 0; i < stikp.size(); i++) {
         rats::rotm3times(target_link_R[i], target_ee_R[i], stikp[i].localR.transpose());
         target_link_p[i] = target_ee_p[i] - target_ee_R[i] * stikp[i].localCOPPos;
@@ -1644,31 +1642,16 @@ void Stabilizer::calcEEForceMomentControl() {
       limbStretchAvoidanceControl(tmpp ,tmpR);
 
       // IK
-//      for (size_t i = 0; i < stikp.size(); i++) {
-//        if (is_ik_enable[i]) {
-//          for (size_t jj = 0; jj < stikp[i].ik_loop_count; jj++) {
-//            jpe_v[i]->calcInverseKinematics2Loop(tmpp[i], tmpR[i], 1.0, 0.001, 0.01, &qrefv, transition_smooth_gain,
-//                                                 //stikp[i].localCOPPos;
-//                                                 stikp[i].localp,
-//                                                 stikp[i].localR);
-//          }
-//        }
-//      }
-
-      ////////// sample fly wheel control ///////////
-      static hrp::Vector3 com_am_tmp = hrp::Vector3::Zero(),  com_am_lpf = hrp::Vector3::Zero();//角運動量とそのローパスフィルタ版
-      hrp::Vector3 com_dam;//角運動量変化分
-      hrp::Vector3 zmp_diff = act_zmp - ref_zmp;
-      if(zmp_diff.norm() > 0.2){ zmp_diff = zmp_diff.normalized() * 0.2; }
-      else if(zmp_diff.norm() < 0.05){ zmp_diff.fill(0); com_am_tmp *= 0.99;}
-      com_dam(0) = -zmp_diff(1) * m_robot->totalMass() * 9.8;
-      com_dam(1) = +zmp_diff(0) * m_robot->totalMass() * 9.8;
-      com_dam(2) = 0;
-      com_am_tmp += com_dam * dt;
-      if(com_am_tmp.norm() > 10){ com_am_tmp = com_am_tmp.normalized() * 10; }//最大発揮角運動量を頭打ち
-      com_am_lpf = com_am_lpf * 0.999 + com_am_tmp * 0.001;
-      hrp::Vector3 com_am_hpf = com_am_tmp - com_am_lpf;//最終的に使う角運動量はハイパスフィルタをかけたもの
-      solveFullbodyIK(m_robot->rootLink()->p, m_robot->rootLink()->R, tmpp, tmpR, ref_cog_wld, com_am_hpf);
+      for (size_t i = 0; i < stikp.size(); i++) {
+        if (is_ik_enable[i]) {
+          for (size_t jj = 0; jj < stikp[i].ik_loop_count; jj++) {
+            jpe_v[i]->calcInverseKinematics2Loop(tmpp[i], tmpR[i], 1.0, 0.001, 0.01, &qrefv, transition_smooth_gain,
+                                                 //stikp[i].localCOPPos;
+                                                 stikp[i].localp,
+                                                 stikp[i].localR);
+          }
+        }
+      }
 }
 
 // Swing ee compensation.
@@ -1793,83 +1776,6 @@ void Stabilizer::calcDiffFootOriginExtMoment ()
                   << "diff ext_moment = " << diff_foot_origin_ext_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[mm]" << std::endl;
     }
 };
-
-void Stabilizer::solveFullbodyIK(
-        const hrp::Vector3& base_pos, const hrp::Matrix33& base_rot,
-        const std::vector<hrp::Vector3>& ee_pos, const std::vector<hrp::Matrix33>& ee_rot,
-        const hrp::Vector3& com_pos, const hrp::Vector3& com_am){
-
-    static hrp::Vector3 root_p = m_robot->rootLink()->p;
-    static hrp::Matrix33 root_R = m_robot->rootLink()->R;
-
-    m_robot->rootLink()->p = root_p;
-    m_robot->rootLink()->R = root_R;
-    setQAll(m_robot, qorg);
-
-    std::vector<IKConstraint> ik_tgt_list;
-    {
-        IKConstraint tmp;
-        tmp.target_link_name = "WAIST";
-        tmp.localPos = hrp::Vector3::Zero();
-        tmp.localR = hrp::Matrix33::Identity();
-        tmp.targetPos = base_pos;// will be ignored by selection_vec
-        tmp.targetRpy = hrp::rpyFromRot(base_rot);
-    //        tmp.constraint_weight << 0,0,0,1e-6,1e-6,1e-6;// don't let base rot free (numerical error problem) 最小1e-6?
-        tmp.constraint_weight << 0,0,0,1,1,1;// フライホイール動作時にベースリンクの回転拘束きついと腕にしわ寄せが行って暴れやすい
-        if(control_mode != MODE_ST) tmp.constraint_weight << 0,0,0,1,1,1;//transition中に回転フリーは危ない
-        ik_tgt_list.push_back(tmp);
-    }
-    for (size_t i = 0; i < stikp.size(); i++) {
-      if (is_ik_enable[i]) {
-          IKConstraint tmp;
-          tmp.target_link_name = stikp[i].target_name;
-          tmp.localPos = stikp[i].localp;
-          tmp.localR = stikp[i].localR;
-          tmp.targetPos = ee_pos[i];
-          tmp.targetRpy = hrp::rpyFromRot(ee_rot[i]);
-          tmp.constraint_weight << 1,1,1,1,1,1;
-          ik_tgt_list.push_back(tmp);
-      }
-    }{
-        IKConstraint tmp;
-        tmp.target_link_name = "COM";
-        tmp.localPos = hrp::Vector3::Zero();
-        tmp.localR = hrp::Matrix33::Identity();
-        tmp.targetPos = com_pos;// COM height will not be constraint
-        tmp.targetRpy = com_am;//reference angular momentum
-        tmp.constraint_weight << 1,1,1,0.1,0.1,0.1;// consider angular momentum (JAXON)
-        if(control_mode != MODE_ST) tmp.constraint_weight.tail(3).fill(0);// disable angular momentum control in transition
-        ik_tgt_list.push_back(tmp);
-    }
-    // knee stretch protection
-    if(m_robot->link("RLEG_JOINT3") != NULL) m_robot->link("RLEG_JOINT3")->llimit = deg2rad(10);
-    if(m_robot->link("LLEG_JOINT3") != NULL) m_robot->link("LLEG_JOINT3")->llimit = deg2rad(10);
-    if(m_robot->link("R_KNEE_P") != NULL) m_robot->link("R_KNEE_P")->llimit = deg2rad(10);
-    if(m_robot->link("L_KNEE_P") != NULL) m_robot->link("L_KNEE_P")->llimit = deg2rad(10);
-    // weight setting
-    for(int i=0;i<m_robot->numLinks();i++){
-        if(m_robot->link(i)->name.find("ARM_JOINT") != std::string::npos){
-            fik->dq_weight_all(m_robot->link(i)->jointId) = 10;
-            fik->q_ref_constraint_weight(m_robot->link(i)->jointId) = 1e-5;
-        }
-        else if(m_robot->link(i)->name.find("CHEST_JOINT") != std::string::npos){
-            fik->q_ref_constraint_weight(m_robot->link(i)->jointId) = 1e-6;
-        }
-        else if(m_robot->link(i)->name.find("HEAD_JOINT") != std::string::npos){
-            fik->q_ref_constraint_weight(m_robot->link(i)->jointId) = 1e-6;
-        }
-    }
-    fik->dq_weight_all.tail(3).fill(1e1);//ベースリンク回転変位の重みは1e1以下は暴れる？
-    fik->q_ref = qrefv;
-
-    int loop_result = 0;
-    const int IK_MAX_LOOP = 1;
-    loop_result = fik->solveFullbodyIKLoop(m_robot, ik_tgt_list, IK_MAX_LOOP);
-
-    root_p = m_robot->rootLink()->p;
-    root_R = m_robot->rootLink()->R;
-}
-
 
 /*
 RTC::ReturnCode_t Stabilizer::onAborting(RTC::UniqueId ec_id)

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -29,7 +29,6 @@
 #include "../ImpedanceController/JointPathEx.h"
 #include "../ImpedanceController/RatsMatrix.h"
 #include "../TorqueFilter/IIRFilter.h"
-#include "../AutoBalancer/FullbodyInverseKinematicsSolver.h"
 
 // </rtc-template>
 
@@ -152,7 +151,6 @@ class Stabilizer
       return (transition_time / dt);
   };
   void calcDiffFootOriginExtMoment ();
-  void solveFullbodyIK(const hrp::Vector3& base_pos, const hrp::Matrix33& base_rot, const std::vector<hrp::Vector3>& ee_pos, const std::vector<hrp::Matrix33>& ee_rot, const hrp::Vector3& com_pos, const hrp::Vector3& com_am);
 
  protected:
   // Configuration variable declaration
@@ -336,9 +334,6 @@ class Stabilizer
   double total_mass, transition_time, cop_check_margin, contact_decision_threshold;
   std::vector<double> cp_check_margin, tilt_margin;
   OpenHRP::StabilizerService::EmergencyCheckMode emergency_check_mode;
-  typedef boost::shared_ptr<FullbodyInverseKinematicsSolver> fikPtr;
-  fikPtr fik;
-  hrp::Vector3 ref_cog_wld;
 };
 
 


### PR DESCRIPTION
Stabilierのmasterからのdiffを無くします。

フライホイールモデルとfullbody-ikを使用するチュートリアルとしてよくできていると思うのですが、auto-stabilizerブランチのdiffを小さくしないと管理しきれないので、auto-stabilizerブランチから分けて、このコミットのリンクをチュートリアル資料に貼るくらいで良いのではないかと思います。