### PR TITLE
[AutoBalancer/Stablizer] fix filter hz for act_contact_states

### DIFF
--- a/rtc/AutoBalancer/Stabilizer.cpp
+++ b/rtc/AutoBalancer/Stabilizer.cpp
@@ -1307,7 +1307,7 @@ bool Stabilizer::calcZMP(hrp::Vector3& ret_zmp, const double zmp_z, hrp::Matrix3
     copInfo[i*3] = tmpcopmx;
     copInfo[i*3+1] = tmpcopmy;
     copInfo[i*3+2] = tmpcopfz;
-    prev_act_force[i] = 0.85 * prev_act_force[i] + 0.15 * rel_nf; // filter, cut off 5[Hz]
+    prev_act_force[i] = 0.95 * prev_act_force[i] + 0.05 * rel_nf; // filter, cut off 5[Hz]
     tmpfz2 += prev_act_force[i](2);
   }
   if (tmpfz2 < contact_decision_threshold) {


### PR DESCRIPTION
階段昇降時に、逆運動学が不安定になって遊脚が空中で僅かに振動したときに、earlyTouchDownを誤検出して遊脚が止まってしまうことが頻発しました。そのとき、ここを変えると誤検出しにくくなりました。

この直し方はテンポラリフィックス感が強いので、あくまでも情報共有としてDraftにしておきます。